### PR TITLE
Fix broken -q option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -46,7 +46,7 @@ init_parse_options(int argc, char **argv)
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "abcd:e:hmnqw:g:st:uv+:";
+   static char stropts[] = "abcd:e:hmnq:w:g:st:uv+:";
    static struct option lopts[] = {
       /* actions */
       {"help", 0, 0, 'h'},                  /* okay */


### PR DESCRIPTION
The missing colon causes a segfault due to no argument being provided.
Very old bug...